### PR TITLE
[DIT-521] Make IUpshotOracle interface more generic

### DIFF
--- a/contracts/IUpshotOracle.sol
+++ b/contracts/IUpshotOracle.sol
@@ -14,6 +14,7 @@ struct PriceData {
     uint96 expiration;
     uint256 nftId;
     uint256 price; 
+    bytes extraData;
 }
 
 /**
@@ -24,23 +25,16 @@ interface IUpshotOracle {
     // * ========================= EVENTS ========================== *
     // ***************************************************************
     event UpshotOracleAdminSetAuthenticator(address authenticator);
-    event UpshotOracleAdminSetNonce();
 
     // ***************************************************************
     // * ========================= ERRORS ========================== *
     // ***************************************************************
     error UpshotOracleInvalidPriceTime();
     error UpshotOracleInvalidSigner();
-    error UpshotOracleInvalidNonce();
 
     // ***************************************************************
     // * ========================== VIEW =========================== *
     // ***************************************************************
-
-    /**
-     * @dev Get current nonce by NFT collection address
-     */
-    function getNonce(address collection) external view returns (uint256 nonce);
 
     /**
      * @notice Get the address of the authenticator

--- a/contracts/UpshotOracle.sol
+++ b/contracts/UpshotOracle.sol
@@ -17,6 +17,9 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
     
     address private _authenticator;
 
+    event UpshotOracleAdminSetNonce();
+    error UpshotOracleInvalidNonce();
+
     constructor (address authenticator_) Ownable(msg.sender) {
         _setAuthenticator(authenticator_);
     }
@@ -105,6 +108,7 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
 
     /**
      * @notice Admin function to set the nonce for the collection
+     * nonce is used to invalidate all prices for a collection at once
      * 
      * @param collection The collection to update the nonce for
      * @param nonce The new nonce
@@ -119,9 +123,10 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
     // ***************************************************************
 
     /**
-     * @inheritdoc IUpshotOracle
+     * @notice Get current nonce by NFT collection address
+     * nonce is used to invalidate all prices for a collection at once
      */
-    function getNonce(address collection) public view override returns (uint256 nonce) {
+    function getNonce(address collection) public view returns (uint256 nonce) {
         nonce = _collectionNonce[collection];
     }
 

--- a/contracts/test/UpshotOracle.t.sol
+++ b/contracts/test/UpshotOracle.t.sol
@@ -25,7 +25,8 @@ contract UpshotOracleUnitTests is Test {
         token: address(0xbeef),
         expiration: type(uint32).max,
         nftId: type(uint256).max,
-        price: 1
+        price: 1,
+        extraData: ""
     });
 
     function setUp() public {


### PR DESCRIPTION
Adds `extraData` field to priceData struct
moves nonce related events and errors into UpshotOracle specific implementation.