### PR TITLE
[DIT-534] Verify signature on oracle extraData field

### DIFF
--- a/contracts/UpshotOracle.sol
+++ b/contracts/UpshotOracle.sol
@@ -53,7 +53,8 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
                         data.token, 
                         data.price, 
                         data.timestamp,
-                        data.expiration
+                        data.expiration,
+                        data.extraData
                     )),
                     data.signature
                 );
@@ -80,7 +81,8 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
         address token,
         uint256 price, 
         uint96 timestamp,
-        uint96 expiration
+        uint96 expiration,
+        bytes memory extraData
     ) public view returns (bytes32) {
         return keccak256(abi.encodePacked(
             block.chainid, 
@@ -90,7 +92,8 @@ contract UpshotOracle is Ownable2Step, IUpshotOracle {
             token,
             price, 
             timestamp,
-            expiration
+            expiration,
+            extraData
         ));
     }
 

--- a/contracts/test/UpshotOracle.t.sol
+++ b/contracts/test/UpshotOracle.t.sol
@@ -68,7 +68,8 @@ contract UpshotOracleUnitTests is Test {
             address(0xcafe),
             type(uint256).max,
             1682691526,
-            9999999999
+            9999999999,
+            ""
         );
         assertEq(correct, actual);
     }
@@ -365,7 +366,8 @@ contract UpshotOracleUnitTests is Test {
                     data.token, 
                     data.price, 
                     data.timestamp,
-                    data.expiration
+                    data.expiration,
+                    data.extraData
                 )   
             )
         );


### PR DESCRIPTION
In [DIT-521] we added an extraData field, but did not actually verify that data - it was not part of the signature. This commit forces the smart contract to verify that the data under the extraData field was not tampered with by an intermediate party before being submitted on chain.